### PR TITLE
Show 'Resume' instead of 'Play' after stopping radio

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -173,6 +173,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const volumeSlider = document.getElementById('volumeSlider');
 
     if (audio && playButton && volumeSlider) {
+        let hasPlayedBefore = false;
+
+        // Preserve initial button text if it's custom (e.g., "Listen to Zamrock")
+        const initialText = playButton.textContent;
+
         // Initialize volume
         audio.volume = volumeSlider.value / 100;
 
@@ -181,12 +186,13 @@ document.addEventListener('DOMContentLoaded', () => {
             if (audio.paused) {
                 audio.play().then(() => {
                     playButton.textContent = 'Stop';
+                    hasPlayedBefore = true;
                 }).catch(() => {
                     // handle errors if needed
                 });
             } else {
                 audio.pause();
-                playButton.textContent = 'Play';
+                playButton.textContent = hasPlayedBefore ? 'Resume' : initialText;
             }
         });
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,204 +1,207 @@
+/* global Image */
+
 // Static header text
-const headerElement = document.querySelector('h1.site-title');
-const headerText = "ZamRock Radio";
+const headerElement = document.querySelector('h1.site-title')
+const headerText = 'ZamRock Radio'
 
 // Ensure header has a link
 if (headerElement && !headerElement.querySelector('a')) {
-    const link = document.createElement('a');
-    link.href = 'https://zamrock.net';
-    link.textContent = headerElement.textContent;
-    headerElement.textContent = '';
-    headerElement.appendChild(link);
+  const link = document.createElement('a')
+  link.href = 'https://zamrock.net'
+  link.textContent = headerElement.textContent
+  headerElement.textContent = ''
+  headerElement.appendChild(link)
 }
 
 // Array of titles for tab animation
 const titles = [
-    "24m20ck 24d10",
-    "Z4m20ck 24d10",
-    "Z4m20ck R4d10",
-    "Z4mR0ck R4d10",
-    "Z4mR0ck R4di0",
-    "ZamR0ck R4di0",
-    "ZamR0ck R4dio",
-    "ZamRock R4dio",
-    "ZamRock Radio",
-    "ZamRock Radio.",
-    "ZamRock Radio..",
-    "ZamRock Radio...",
-    "ZamRock Radio..!",
-    "ZamRock Radio.!",
-    "ZamRock Radio!",
-    "ZamRock Radio;!",
-    "ZamRock Radio ;!",
-    "ZamRock Radio ;P",
-    "ZamRock Radio",
-    "ZamRock Radio",
-    "ZamRock R4dio",
-    "ZamR0ck R4dio",
-    "ZamR0ck R4di0",
-    "Z4mR0ck R4di0",
-    "Z4mR0ck R4d10",
-    "Z4m20ck R4d10",
-    "Z4m20ck 24d10",
-    "24m20ck 24d10"
-];
+  '24m20ck 24d10',
+  'Z4m20ck 24d10',
+  'Z4m20ck R4d10',
+  'Z4mR0ck R4d10',
+  'Z4mR0ck R4di0',
+  'ZamR0ck R4di0',
+  'ZamR0ck R4dio',
+  'ZamRock R4dio',
+  'ZamRock Radio',
+  'ZamRock Radio.',
+  'ZamRock Radio..',
+  'ZamRock Radio...',
+  'ZamRock Radio..!',
+  'ZamRock Radio.!',
+  'ZamRock Radio!',
+  'ZamRock Radio;!',
+  'ZamRock Radio ;!',
+  'ZamRock Radio ;P',
+  'ZamRock Radio',
+  'ZamRock Radio',
+  'ZamRock R4dio',
+  'ZamR0ck R4dio',
+  'ZamR0ck R4di0',
+  'Z4mR0ck R4di0',
+  'Z4mR0ck R4d10',
+  'Z4m20ck R4d10',
+  'Z4m20ck 24d10',
+  '24m20ck 24d10'
+]
 
-let currentTitleIndex = 0;
+let currentTitleIndex = 0
 
 // Function to animate tab title with random intervals
-function animateTabTitle() {
-    document.title = titles[currentTitleIndex];
-    currentTitleIndex = (currentTitleIndex + 1) % titles.length;
+function animateTabTitle () {
+  document.title = titles[currentTitleIndex]
+  currentTitleIndex = (currentTitleIndex + 1) % titles.length
 
-    const interval = Math.floor(Math.random() * 2000) + 500;
-    setTimeout(animateTabTitle, interval);
+  const interval = Math.floor(Math.random() * 2000) + 500
+  setTimeout(animateTabTitle, interval)
 }
 
 // Start the tab title animation
-setTimeout(animateTabTitle, 1000);
+setTimeout(animateTabTitle, 1000)
 
 // Keep header text content up to date while preserving the link
 if (headerElement) {
-    const link = headerElement.querySelector('a');
-    if (link) {
-        link.textContent = headerText;
-    } else {
-        headerElement.textContent = headerText;
-        // Add link if it was missing
-        const newLink = document.createElement('a');
-        newLink.href = 'https://zamrock.net';
-        newLink.textContent = headerText;
-        headerElement.textContent = '';
-        headerElement.appendChild(newLink);
-    }
+  const link = headerElement.querySelector('a')
+  if (link) {
+    link.textContent = headerText
+  } else {
+    headerElement.textContent = headerText
+    // Add link if it was missing
+    const newLink = document.createElement('a')
+    newLink.href = 'https://zamrock.net'
+    newLink.textContent = headerText
+    headerElement.textContent = ''
+    headerElement.appendChild(newLink)
+  }
 }
 
 // Mobile menu toggle function
-function toggleMenu(event) {
-    if (event) event.preventDefault();
-    const menu = document.querySelector('.nav-menu');
-    if (menu) {
-        menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
-    }
+// eslint-disable-next-line no-unused-vars
+function toggleMenu (event) {
+  if (event) event.preventDefault()
+  const menu = document.querySelector('.nav-menu')
+  if (menu) {
+    menu.style.display = menu.style.display === 'block' ? 'none' : 'block'
+  }
 }
 
 // Close menu when clicking outside
 window.addEventListener('click', (event) => {
-    const menu = document.querySelector('.nav-menu');
-    const menuToggle = document.querySelector('.mobile-menu-toggle');
-    
-    if (menu && menuToggle && !menu.contains(event.target) && !menuToggle.contains(event.target)) {
-        menu.style.display = 'none';
-    }
-});
+  const menu = document.querySelector('.nav-menu')
+  const menuToggle = document.querySelector('.mobile-menu-toggle')
+
+  if (menu && menuToggle && !menu.contains(event.target) && !menuToggle.contains(event.target)) {
+    menu.style.display = 'none'
+  }
+})
 
 // Handle window resize
 window.addEventListener('resize', () => {
-    const menu = document.querySelector('.nav-menu');
-    const menuToggle = document.querySelector('.mobile-menu-toggle');
-    
-    if (window.innerWidth > 768) {
-        if (menu) menu.style.display = '';
-    } else if (menuToggle && menu) {
-        menu.style.display = 'none';
-    }
-});
+  const menu = document.querySelector('.nav-menu')
+  const menuToggle = document.querySelector('.mobile-menu-toggle')
+
+  if (window.innerWidth > 768) {
+    if (menu) menu.style.display = ''
+  } else if (menuToggle && menu) {
+    menu.style.display = 'none'
+  }
+})
 
 // Background images array with full URLs
 const backgroundImages = [
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_001.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_002.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_003.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_004.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_005.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_006.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_007.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_008.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_009.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_010.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_011.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_012.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_013.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_014.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_015.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_016.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_017.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_018.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_019.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_020.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_021.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_022.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_023.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_024.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_025.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_026.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_027.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_028.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_029.jpg',
-    'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_030.jpg'
-];
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_001.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_002.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_003.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_004.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_005.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_006.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_007.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_008.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_009.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_010.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_011.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_012.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_013.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_014.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_015.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_016.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_017.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_018.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_019.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_020.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_021.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_022.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_023.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_024.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_025.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_026.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_027.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_028.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_029.jpg',
+  'https://raw.githubusercontent.com/DeathSmack/zamrock/main/docs/img/website_bg/website_bg_030.jpg'
+]
 
-function setRandomBackground() {
-    if (backgroundImages.length === 0) return;
-    const randomImage = backgroundImages[Math.floor(Math.random() * backgroundImages.length)];
-    
-    // Preload the image before setting it as background
-    const img = new Image();
-    img.onload = function() {
-        // Only update the background if the image loads successfully
-        document.body.style.backgroundImage = `url('${randomImage}')`;
-        document.body.style.backgroundSize = 'cover';
-        document.body.style.backgroundPosition = 'center';
-        document.body.style.backgroundAttachment = 'fixed';
-        document.body.style.backgroundRepeat = 'no-repeat';
-    };
-    img.src = randomImage;
+function setRandomBackground () {
+  if (backgroundImages.length === 0) return
+  const randomImage = backgroundImages[Math.floor(Math.random() * backgroundImages.length)]
+
+  // Preload the image before setting it as background
+  const img = new Image()
+  img.onload = function () {
+    // Only update the background if the image loads successfully
+    document.body.style.backgroundImage = `url('${randomImage}')`
+    document.body.style.backgroundSize = 'cover'
+    document.body.style.backgroundPosition = 'center'
+    document.body.style.backgroundAttachment = 'fixed'
+    document.body.style.backgroundRepeat = 'no-repeat'
+  }
+  img.src = randomImage
 }
 
 // Initialize background rotation on page load
 document.addEventListener('DOMContentLoaded', () => {
-    // Set initial background
-    setRandomBackground();
-    
-    // Rotate background every 20 seconds
-    const backgroundInterval = setInterval(setRandomBackground, 20000);
-    
-    // Cleanup interval when page is unloaded
-    window.addEventListener('beforeunload', () => {
-        clearInterval(backgroundInterval);
-    });
+  // Set initial background
+  setRandomBackground()
 
-    const audio = document.getElementById('radioStream');
-    const playButton = document.getElementById('playButton');
-    const volumeSlider = document.getElementById('volumeSlider');
+  // Rotate background every 20 seconds
+  const backgroundInterval = setInterval(setRandomBackground, 20000)
 
-    if (audio && playButton && volumeSlider) {
-        let hasPlayedBefore = false;
+  // Cleanup interval when page is unloaded
+  window.addEventListener('beforeunload', () => {
+    clearInterval(backgroundInterval)
+  })
 
-        // Preserve initial button text if it's custom (e.g., "Listen to Zamrock")
-        const initialText = playButton.textContent;
+  const audio = document.getElementById('radioStream')
+  const playButton = document.getElementById('playButton')
+  const volumeSlider = document.getElementById('volumeSlider')
 
-        // Initialize volume
-        audio.volume = volumeSlider.value / 100;
+  if (audio && playButton && volumeSlider) {
+    let hasPlayedBefore = false
 
-        // Play/pause toggle
-        playButton.addEventListener('click', () => {
-            if (audio.paused) {
-                audio.play().then(() => {
-                    playButton.textContent = 'Stop';
-                    hasPlayedBefore = true;
-                }).catch(() => {
-                    // handle errors if needed
-                });
-            } else {
-                audio.pause();
-                playButton.textContent = hasPlayedBefore ? 'Resume' : initialText;
-            }
-        });
+    // Preserve initial button text if it's custom (e.g., "Listen to Zamrock")
+    const initialText = playButton.textContent
 
-        // Adjust volume
-        volumeSlider.addEventListener('input', () => {
-            audio.volume = volumeSlider.value / 100;
-        });
-    }
-});
+    // Initialize volume
+    audio.volume = volumeSlider.value / 100
+
+    // Play/pause toggle
+    playButton.addEventListener('click', () => {
+      if (audio.paused) {
+        audio.play().then(() => {
+          playButton.textContent = 'Stop'
+          hasPlayedBefore = true
+        }).catch(() => {
+          // handle errors if needed
+        })
+      } else {
+        audio.pause()
+        playButton.textContent = hasPlayedBefore ? 'Resume' : initialText
+      }
+    })
+
+    // Adjust volume
+    volumeSlider.addEventListener('input', () => {
+      audio.volume = volumeSlider.value / 100
+    })
+  }
+})


### PR DESCRIPTION
Track if audio has been played before, show 'Resume' when stopped instead of reverting to initial button text.